### PR TITLE
change old cemerick/piggeback to cider/piggieback

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/core.async "0.4.490"]
-                 [com.cemerick/piggieback "0.2.2"]
+                 [cider/piggieback "0.3.10"]
                  [compojure "1.6.1"]
                  [duct/core "0.7.0"]
                  [figwheel-sidecar "0.5.18"]

--- a/src/duct/server/figwheel.clj
+++ b/src/duct/server/figwheel.clj
@@ -1,6 +1,6 @@
 (ns duct.server.figwheel
   "Integrant methods for running a Figwheel server."
-  (:require [cemerick.piggieback :as piggieback]
+  (:require [cider.piggieback :as piggieback]
             [cljs.repl :as repl]
             [cljs.stacktrace :as stacktrace]
             [clojure.java.io :as io]


### PR DESCRIPTION
old piggieback doesn't work with latest cider (0.20.0). This update fixes that.
Cider's guide: https://cider.readthedocs.io/en/latest/clojurescript/