### PR TITLE
CLJS REPL to support multiple build ID

### DIFF
--- a/src/duct/repl/figwheel.clj
+++ b/src/duct/repl/figwheel.clj
@@ -2,5 +2,8 @@
   (:require [integrant.repl.state :as state]
             [duct.server.figwheel :as figwheel]))
 
-(defn cljs-repl []
-  (figwheel/cljs-repl (:duct.server/figwheel state/system)))
+(defn cljs-repl
+  ([]
+   (figwheel/cljs-repl (:duct.server/figwheel state/system)))
+  ([build-id]
+   (figwheel/cljs-repl (:duct.server/figwheel state/system) build-id)))

--- a/src/duct/server/figwheel.clj
+++ b/src/duct/server/figwheel.clj
@@ -136,4 +136,6 @@
   ([{:keys [server prepped]}]
    (start-piggieback-repl server (first prepped)))
   ([{:keys [server prepped]} build-id]
-   (start-piggieback-repl server (-> (group-by :id prepped) (get build-id)))))
+   (start-piggieback-repl server (-> (group-by :id prepped)
+                                     (get build-id)
+                                     first))))


### PR DESCRIPTION
- `duct.repl.figwheel/cljs-repl` to accept `build-id` as an optional argument
- Fix `duct.server.figwheel/cljs-repl` doesn't actually work now when provided a `build-id` argument 