### PR TITLE
Fix NullPointerException when processing externs files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,33 @@ same options as Figwheel.
                               :optimizations :none}}]}}
 ```
 
+By default the library only takes into account files ending in ".css"
+when processing the directories specified in the `:css-dirs` key. If
+you want to process other files as CSS files, you can add the
+`:css-files-pattern` key and specify a string that will be used as a
+regular expression that the relevant files have to match.
+
+Similarly only files ending in ".cljs" or "cljc" will be taken into
+account when processing the directories specified in the
+`:source-paths` key. Again, you can add a `:source-files-pattern` key
+and specify a string that will be used as a regular expression that
+the relevant files have to match. In this case, you need to specify
+the key for each build you specify in the `:builds` vector.
+
+Here is an example with the default patterns:
+
+```edn
+{:duct.server/figwheel
+ {:css-dirs ["dev/resources"]
+  :css-files-pattern "\\.css$"
+  :builds   [{:id :dev
+              :source-paths  ["src"]
+              :source-files-pattern "\\.clj[sc]$"
+              :build-options {:output-to "target/js/public/main.js"
+                              :output-dir "target/js/public"
+                              :optimizations :none}}]}}
+```
+
 See the [Figwheel README][] for more information.
 
 [figwheel readme]: https://github.com/bhauman/lein-figwheel/blob/master/README.md


### PR DESCRIPTION
lein-figwheel expects that all files with .js extension inside its
source directories are foreign libraries. And foreign libraries must
declare a namespace. In fact, lein-figwheel assumes all .js files have
such a namespace declared. And it blindly tries to use it to map the
.js file back to a source .cljs file. When the namespace is not
declared in the .js file, lein-figwheel bombs out with a
NullPointerException when it tries to check if the the source .cljs
file exists.

This might happen when you put your externs file(s) inside the source
directories (this is our case,
e.g. https://github.com/magnetcoop/hydrogen-ce/blob/master/src/hyd/client/externs.js)

lein-figwheel doesn't try to process such files by default on its
own. But when using Duct server.figwheel, it tells lein-figwheel to
process all files inside the configured source directories (see
https://github.com/duct-framework/server.figwheel/blob/master/src/duct/server/figwheel.clj#L54-L55).

Clearly lein-figwheel should be more robust and handle that situation
in a more graceful way[1]. On the other hand Duct server.figwheel
shouldn't be telling lein-figwheel to process absolutely all files in
source directories. It doesn't make sense to process .clj files, .edn
files, etc. Probably just those having .cljs/.cljc extension and those
declared as foreign libraries.

In issue #7 James Reeves suggested that instead of hard-coding the
list of files to process by lein-figwheel, we should have configurable
options with default values. And he suggested using a regular
expression for matching filenames.

[1] We opened a pull request in lein-figwheel regarding this
    behaviour, see bhauman/lein-figwheel#739. It has been fixed since
    then and included in figwheel-sidecar 0.5.20. But Duct
    server.figwheel is still using figwheel-sidecar 0.5.18